### PR TITLE
Added LICENSE to the POD

### DIFF
--- a/lib/Alien/NSS.pm
+++ b/lib/Alien/NSS.pm
@@ -83,3 +83,7 @@ L<https://github.com/0xxon/alien-nss>
 =head1 AUTHOR
 
 Johanna Amann, E<lt>johanna@cpan.orgE<gt>
+
+=head1 LICENSE
+
+See the LICENSE file for license information.


### PR DESCRIPTION
According to CPANTS
http://cpants.cpanauthors.org/dist/Alien-NSS
Kwalitee recommends that you place your License information in the Documentation. I noticed you had a LICENSE file detailing all the license for your module. So, I simply added the LICENSE line that Kwalitee was looking for and referenced your clearly labeled file in it. Now CPANTS should be happy ... I assume.
