### PR TITLE
Move to https. Set fallback version to 3.52. Pattern more permissive. Url changed

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -72,10 +72,10 @@ my $builder = Alien::NSS::ModuleBuild->new (
 	dist_author => 'Johanna Amann <johanna@icir.org>',
 	alien_name => 'nss',
 	alien_repository => {
-		protocol => 'http',
+		protocol => 'https',
 		host => 'ftp.mozilla.org',
-		location => 'pub/mozilla.org/security/nss/releases/NSS_3_20_RTM/src/',
-		pattern  => qr/^nss-([\d\.]+)-with-nspr-.*\.tar\.gz$/,
+		location => 'pub/security/nss/releases/NSS_3_52_RTM/src/',
+		pattern  => qr/^.*-with-nspr-.*\.tar\.gz$/,
 	},
 	# who needs configure, etc.
 	alien_install_commands => [
@@ -135,7 +135,7 @@ if ( !defined($version) ) {
 
 die "Could not determine current automatically, please specify with --version" if (!defined($version));
 
-my $location = "pub/mozilla.org/security/nss/releases/NSS_".$version."_RTM/src/";
+my $location = "pub/security/nss/releases/NSS_".$version."_RTM/src/";
 $builder->alien_repository->{location} = $location;
 warn "wanted NSS path: $location\n";
 


### PR DESCRIPTION
Hello :smiley: 

First thank you for this Alien module :)

I have issues to install this module, see for instance this [failed build](https://github.com/thibaultduponchelle/aliens-ci/runs/652828510?check_suite_focus=true).

There are multiple reasons, one of these being linked to the @plicease PR that seems to never reach CPAN but not only.

The url seems to have changed a bit (even being redirected). I don't know why but the pattern seems too strict (I'm not an expert of regex, I just put something more permissive that worked for me) and I moved to https.

I hope you can merge this PR and maybe prepare a CPAN release in the future :grin: 

It should fix also this [RT issue](https://github.com/0xxon/alien-nss/issues/5)

/cc @plicease 

Best regards.

Thibault
